### PR TITLE
Fix categorical merge - default `method` from `mode` to `min`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2025-01-18
+
+* Fixed default keyword argument for `merge_categorical_arrays` from `mode` (not possible with rasterio) to `min`.
+
+
 ## [0.0.5] - 2025-01-18
 
 ### Added

--- a/src/distmetrics/rio_tools.py
+++ b/src/distmetrics/rio_tools.py
@@ -121,7 +121,7 @@ def merge_categorical_arrays(
     profiles: list[dict],
     target_crs: CRS | None = None,
     exterior_mask_dilation: int = 0,
-    merge_method: str = 'mode',
+    merge_method: str = 'min',
 ) -> tuple[np.ndarray, dict]:
     arrs_r, profiles_target = reproject_arrays_to_target_crs(
         arrs, profiles, target_crs=target_crs, resampling_method='nearest'


### PR DESCRIPTION
See `rasterio.merge.merge`.