### PR TITLE
Inference Speedup Suggestions

### DIFF
--- a/src/distmetrics/transformer.py
+++ b/src/distmetrics/transformer.py
@@ -2,6 +2,7 @@ import platform
 from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Union
+import math
 
 import einops
 import numpy as np
@@ -303,7 +304,7 @@ def _estimate_logit_params_via_streamed_patches(
     n_patches_x = int(np.floor((W - P) / stride) + 1)
     n_patches = n_patches_y * n_patches_x
 
-    n_batches = n_patches // batch_size + 1
+    n_batches = math.ceil(n_patches / batch_size)
 
     target_shape = (C, H, W)
     count = torch.zeros(*target_shape).to(device)
@@ -425,7 +426,7 @@ def _estimate_logit_params_via_folding(
     # n_patches x T x C x P**2
     patches = patches.view(n_patches, T, C, P**2)
 
-    n_batches = n_patches // batch_size + 1
+    n_batches = math.ceil(n_patches / batch_size)
 
     target_chip_shape = (n_patches, C, P, P)
     pred_means_p = torch.zeros(*target_chip_shape).to(device)


### PR DESCRIPTION
This PR suggests two improvements to speed up inference on both CPU and GPU platforms.

> [!WARNING]
> Please change the target to a different branch to confirm that this works before merging into `dev`. I have not had a chance to actually test this code.

# Description

## TorchScript Just-In-Time (JIT) Compilation

This performs a set of optimizations that assumes the model will only be used for inference. While this is not guaranteed to make the model faster, the documentation notes that special attention was paid to improve vision models on cpu.

This was implemented in the `load_transformer_model()` function with an added argument, `optimize`, which defaults to False. Setting `optimize=True` will return a JIT compiled model instead of the default model in eval mode.

```python
# TorchScript Just-In-Time (JIT) compilation
# Performs a set of optimization passes to optimize a model for inference
# This is still a prototype, and may have the potential to slow down your model.
# Primary use cases that have been targeted so far have been vision models on cpu
# and gpu to a lesser extent.
# References:
# https://pytorch.org/docs/stable/generated/torch.jit.optimize_for_inference.html
# https://residentmario.github.io/pytorch-training-performance-guide/jit.html
if optimize:
    transformer = torch.jit.optimize_for_inference(torch.jit.script(transformer.eval()))
else:
    transformer = transformer.eval()
return transformer
```

Benchmarks should be performed to confirm that this does, in fact, result in a speedup. Certain configurations of CPUs, instruction sets, and libraries may prevent improvement.

## Automatic Mixed Precision (AMP) bfloat16 Casting

This casts both the model and data to [`brainfloat16`](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) if the device/environment allows for it, theoretically falling back to `float32` if it does not allow it. Please note that [only some CPUs natively support `bfloat16` (Intel Cooper Lake w/ Intel AVX-512, etc.)](https://pytorch.org/blog/empowering-pytorch-on-intel-xeon-scalable-processors-with-bfloat16/) whereas all Nvidia GPUs support `bfloat16`. 

This was implemented in the `_estimate_logit_params_via_streamed_patches()` and `_estimate_logit_params_via_folding()` functions, either called by `estimate_normal_params_of_logits()` (which in turn is called by `compute_transformer_zscore()`) depending on the memory strategy. 

```python
# Use torch Automatic Mixed Precision (AMP) to speed up inference if appropriate
# Note: this requires torch >= 1.12.0 and either an Nvidia GPU or an Intel Xeon CPU with native support for bfloat16
# AMP will automatically determine if the hardware supports bfloat16
# References:
# https://pytorch.org/docs/stable/amp.html
# https://pytorch.org/blog/empowering-pytorch-on-intel-xeon-scalable-processors-with-bfloat16/
with torch.autocast(device_type=device, dtype=torch.bfloat16):
    ...
    chip_mean, chip_logvar = model(patch_batch)
    ...
```

I didn't wrap these in flags to avoid propagating arguments too far up - simply removing these context managers would revert these changes. An alternate way to implement this is to cast the model and data itself:

```python
# with explicit conversion
input = input.to(dtype=torch.bfloat16)
model = model.to(dtype=torch.bfloat16)
```

However, if the model or environment does not support `bfloat16` casting, this will throw an exception.

# Usage

## Implementation

Going off of the notebooks included in this repository, simply replacing with `transformer = load_transformer_model(model_token="latest", optimize=True)` wherever the model is defined in your testing scripts is sufficient to test this PR.

## Potential Issues

- I'm not confident if `bfloat16` will work for your CPU cores; hopefully, if it fails, it will fall back to `float32` with some warning in the logs. If it crashes, you may need to toggle the context manager based on the device string ('cpu' vs 'cuda')
  - More information: https://pytorch.org/blog/empowering-pytorch-on-intel-xeon-scalable-processors-with-bfloat16/
- There could be issues with your pytorch version, CUDA version, CuDNN version, etc.
- JIT compilation may not work for your custom model architecture depending on how it was written.

## Future Work

The goal of this PR is to accomplish enough optimizations to consider if deploying on GPU is cost-effective. If your project does decide to deploy on a GPU, then the end-all best optimization option is TensorRT with ONNX, which is faster than JIT+bfloat16 but requires a bit more setup and development. More information here: 

https://github.com/pytorch/TensorRT
