### PR TITLE
Add model compilation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 2025-03-20
+
+### Added
+* Added optional compilation for `CPU` via `torch.compile` and `GPU` via `torch_tensorrt.compile`.
+
+### Fixed
+* Fixed order of tensor operations and moving data to 'device' to reduce overhead.
+
 ## [0.0.13] - 2025-05-15
 
 ### Added

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ dependencies:
  - asf_search
  - astropy
  - backoff
+ - compilers
  - dem_stitcher
  - einops
  - flake8

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -1,4 +1,7 @@
 name: distmetrics
+channels:
+  - conda-forge
+channel_priority: strict
 dependencies:
  - python>=3.12
  - asf_search
@@ -19,7 +22,6 @@ dependencies:
  - pydantic
  - pytest
  - pytest-cov
- - pytorch
  - rasterio>=1.4.3
  - requests
  - ruff
@@ -31,3 +33,9 @@ dependencies:
  - tqdm
  - pip
  - cudatoolkit>=11.8
+ - pip:
+   - torch 
+   - torchvision 
+   - torchaudio
+   - torch-tensorrt
+   - nvidia-modelopt[all]

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -7,6 +7,7 @@ dependencies:
  - asf_search
  - astropy
  - backoff
+ - compilers
  - dem_stitcher
  - einops
  - flake8

--- a/src/distmetrics/transformer.py
+++ b/src/distmetrics/transformer.py
@@ -338,7 +338,7 @@ def _estimate_logit_params_via_streamed_patches(
     # Mask
     mask_stack = np.isnan(pre_imgs_stack)
     # Remove T x 2 dims
-    mask_spatial = torch.from_numpy(np.any(mask_stack, axis=(0, 1))).to(device, dtype=DEV_DTYPE)
+    mask_spatial = torch.from_numpy(np.any(mask_stack, axis=(0, 1))).to(device)
     assert len(mask_spatial.shape) == 2, 'spatial mask should be 2d'
 
     # Logit transformation
@@ -444,7 +444,7 @@ def _estimate_logit_params_via_folding(
     # Mask
     mask_stack = np.isnan(pre_imgs_stack)
     # Remove T x 2 dims
-    mask_spatial = torch.from_numpy(np.any(mask_stack, axis=(0, 1)))
+    mask_spatial = torch.from_numpy(np.any(mask_stack, axis=(0, 1))).to(device)
     assert len(mask_spatial.shape) == 2, 'spatial mask should be 2d'
 
     # Logit transformation

--- a/src/distmetrics/transformer.py
+++ b/src/distmetrics/transformer.py
@@ -261,7 +261,11 @@ def load_transformer_model(
         if device == "cuda":
             import torch_tensorrt
 
-            expected_dims = (batch_size, 10, 2, 16, 16)
+            # Get dimensions
+            total_pixels = transformer.num_patches * (transformer.patch_size ** 2)
+            wh = math.isqrt(total_pixels)
+            channels = transformer.data_dim // (transformer.patch_size ** 2)
+            expected_dims = (batch_size, transformer.max_seq_len, channels, wh, wh)
 
             transformer = torch_tensorrt.compile(
             transformer,


### PR DESCRIPTION
* Add method to compile models for GPU and CPU when flag `optimization=True` in `load_transformer_model`
* Set `batch_size` in `load_transformer_model` since it is needed for GPU compilation
* Add env variable (experimental) to change tensor dtypes

```
os.environ["DEV_DTYPE"] = "float32" # "bfloat16"
```

* Change the order of some tensor operations and send tensor to device earlier to reduce overhead. 